### PR TITLE
vig_engine0 has been removed from knitr

### DIFF
--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -8,7 +8,7 @@ register_vignette_engines <- function(pkg) {
 
 #' @importFrom knitr knit_filter
 vig_engine <- function(..., tangle = knitr:::vtangle) {
-  knitr:::vig_engine0(..., tangle = tangle, package = "tutorial", aspell = list(
+  tools::vignetteEngine(..., tangle = tangle, package = "tutorial", aspell = list(
     filter = knit_filter
   ))
 }


### PR DESCRIPTION
Use `tools::vignetteEngine()` instead. See https://github.com/yihui/knitr/commit/4c07ef3c3602916b4a2bc53eafab549c2da97df7

In general, it is a bad idea to use unexported functions from other people's packages, since these functions can change any time without notice.

This change in tutorial has to be made since it is blocking the next CRAN release of knitr.