### PR TITLE
knitr:::vig_engine0() function does not exist...install fails

### DIFF
--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -8,8 +8,7 @@ register_vignette_engines <- function(pkg) {
 
 #' @importFrom knitr knit_filter
 vig_engine <- function(..., tangle = knitr:::vtangle) {
-  knitr:::vig_engine(..., tangle = tangle, aspell = list(
-    filter = knit_filter
+  knitr:::vig_engine(..., tangle = tangle
   ))
 }
 

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -8,7 +8,7 @@ register_vignette_engines <- function(pkg) {
 
 #' @importFrom knitr knit_filter
 vig_engine <- function(..., tangle = knitr:::vtangle) {
-  knitr:::vig_engine(..., tangle = tangle, package = "tutorial", aspell = list(
+  knitr:::vig_engine(..., tangle = tangle, aspell = list(
     filter = knit_filter
   ))
 }

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -8,7 +8,7 @@ register_vignette_engines <- function(pkg) {
 
 #' @importFrom knitr knit_filter
 vig_engine <- function(..., tangle = knitr:::vtangle) {
-  knitr:::vig_engine0(..., tangle = tangle, package = "tutorial", aspell = list(
+  knitr:::vig_engine(..., tangle = tangle, package = "tutorial", aspell = list(
     filter = knit_filter
   ))
 }

--- a/R/utils-vignettes.R
+++ b/R/utils-vignettes.R
@@ -8,7 +8,6 @@ register_vignette_engines <- function(pkg) {
 
 #' @importFrom knitr knit_filter
 vig_engine <- function(..., tangle = knitr:::vtangle) {
-  knitr:::vig_engine(..., tangle = tangle
-  ))
+  knitr:::vig_engine(..., tangle = tangle)
 }
 


### PR DESCRIPTION
knitr:::vig_engine does exist, but throws an error trying to parse the default arguments and the arguments you have specified.

My proposed changes allowed me to install the package and successfully run a few examples 