### PR TITLE
Allow any number of `\n` in the test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,6 @@ Description: DataCamp Light (<https://github.com/datacamp/datacamp-light>) is a 
   HTML files from R Markdown files. An extension to knitr, tutorial detects appropriately formatted code chunks and replaces them
   with DataCamp Light readable chunks in the resulting HTML file.
 License: MIT + file LICENSE
-LazyData: TRUE
 Depends: R (>= 3.0.0)
 Imports:
     markdown,

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -18,5 +18,5 @@ test_that("to_html works as expected", {
   expect_equal(to_html("test"), "test")
   expect_equal(to_html("_test_"), "<em>test</em>")
   expect_equal(to_html("__test__"), "<strong>test</strong>")
-  expect_equal(to_html("# title\ntest"), "<h1>title</h1>\n\n<p>test</p>")
+  expect_match(to_html("# title\ntest"), "<h1>title</h1>\n+<p>test</p>")
 })


### PR DESCRIPTION
The **markdown** package v1.3 generates only one `\n` instead of two. Using `expect_match()` can deal with both cases.